### PR TITLE
poppler 0.64.0 compatibility

### DIFF
--- a/src/eng_output_dev.cc
+++ b/src/eng_output_dev.cc
@@ -157,7 +157,7 @@ namespace pdftoedn
                   }
 
                   // found some PDFs where URIs had NULL strings.. huh?
-                  GooString* uri = ha->getURI();
+                  GooString* uri = const_cast<GooString *>(ha->getURI());
                   pdf_link = new PdfAnnotLinkURI(x1, y1, x2, y2, effect,
                                                  ((uri != NULL) ? uri->getCString() : ""));
               }

--- a/src/pdf_font_source.cc
+++ b/src/pdf_font_source.cc
@@ -229,7 +229,7 @@ namespace pdftoedn
         gfx_font_flags(gfx_font->getFlags()),
         encoding(NULL),
         code_to_gid(NULL),
-        to_unicode((gfx_font->getToUnicode() != NULL) && (gfx_font->getToUnicode()->getLength() > 1)),
+        to_unicode((gfx_font->getToUnicode() != NULL) && ((const_cast<CharCodeToUnicode *>(gfx_font->getToUnicode()))->getLength() > 1)),
         ft_lib(lib), ft_face(NULL), face_index(font_face_index),
         font_ok(false)
     {
@@ -251,7 +251,7 @@ namespace pdftoedn
         gfx_font_flags(gfx_font->getFlags()),
         encoding(NULL),
         code_to_gid(NULL),
-        to_unicode((gfx_font->getToUnicode() != NULL) && (gfx_font->getToUnicode()->getLength() > 1)),
+        to_unicode((gfx_font->getToUnicode() != NULL) && ((const_cast<CharCodeToUnicode *>(gfx_font->getToUnicode()))->getLength() > 1)),
         ft_lib(NULL), ft_face(NULL), face_index(-1),
         filename(font_file),
         font_ok(false)

--- a/src/pdf_reader.cc
+++ b/src/pdf_reader.cc
@@ -305,7 +305,7 @@ namespace pdftoedn
         Outline *outline = getOutline();
 
         if (outline && outline->getItems()) {
-            outline_level(outline->getItems(), 0, outline_output.get_entry_list());
+            outline_level(const_cast<GooList *>(outline->getItems()), 0, outline_output.get_entry_list());
             return true;
         }
         return false;
@@ -421,7 +421,7 @@ namespace pdftoedn
             entry_list.push_back(e);
 
             // action shoud get LINK_GOTO
-            LinkAction* link_action = item->getAction();
+            LinkAction* link_action = const_cast<LinkAction *>(item->getAction());
 
             if (link_action)
             {
@@ -444,7 +444,7 @@ namespace pdftoedn
             // traverse the child nodes
             item->open();
             if (item->hasKids()) {
-                outline_level(item->getKids(), level + 1, e->get_entry_list());
+                outline_level(const_cast<GooList *>(item->getKids()), level + 1, e->get_entry_list());
             }
             item->close();
         }


### PR DESCRIPTION
Fix errors like

```
eng_output_dev.cc:160:30: error: cannot initialize a variable of type 'GooString *' with an rvalue of type 'const GooString *'
                  GooString* uri = ha->getURI();
                             ^     ~~~~~~~~~~~~
1 error generated.
```